### PR TITLE
Update EXPExpect+LLReactiveMatchersExtensions.m

### DIFF
--- a/LLReactiveMatchers/Helpers/EXPExpect+LLReactiveMatchersExtensions.m
+++ b/LLReactiveMatchers/Helpers/EXPExpect+LLReactiveMatchersExtensions.m
@@ -11,7 +11,7 @@
 #import "Expecta.h"
 
 #import <libkern/OSAtomic.h>
-#import <objc/objc-runtime.h>
+#import <objc/runtime.h>
 
 @implementation EXPExpect (LLReactiveMatchersExtensions)
 

--- a/Podfile
+++ b/Podfile
@@ -3,3 +3,17 @@ platform :ios, '6.0'
 pod 'ReactiveCocoa'
 pod 'Specta'
 pod 'Expecta'
+
+post_install do |installer|
+    target = installer.project.targets.find { |t| t.to_s == "Pods-Tests-Specta" }
+    if (target)
+        target.build_configurations.each do |config|
+            s = config.build_settings['FRAMEWORK_SEARCH_PATHS']
+            s = [ '$(inherited)' ] if s == nil;
+            s.push('$(PLATFORM_DIR)/Developer/Library/Frameworks')
+            config.build_settings['FRAMEWORK_SEARCH_PATHS'] = s
+        end
+    else
+        puts "WARNING: Pods-Tests-Specta target not found"
+    end
+end


### PR DESCRIPTION
I'm not able to compile this file with the iOS 8.3 device SDK unless I change this header. Bizarrely, the simulator compiles just fine.
